### PR TITLE
Migrate to AndroidX and added indicator gravity 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -25,12 +25,12 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
     implementation project(":lib")
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "me.ibrahimsn.nicebottombar"
-        minSdkVersion 22
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/me/ibrahimsn/nicebottombar/MainActivity.kt
+++ b/app/src/main/java/me/ibrahimsn/nicebottombar/MainActivity.kt
@@ -1,6 +1,6 @@
 package me.ibrahimsn.nicebottombar
 
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
 import kotlinx.android.synthetic.main.activity_main.*

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,6 +10,7 @@
 		android:id="@+id/bottomBar"
 		android:layout_width="match_parent"
 		android:layout_height="60dp"
+		app:indicatorGravity="bottom"
 		android:layout_gravity="bottom"
 	    app:menu="@menu/bottom_menu"
 		app:itemFontFamily="@font/quicksand"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,5 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.useAndroidX=true
+android.enableJetifier=true

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -11,7 +11,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }
 
@@ -27,10 +27,10 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.31"
 }
 repositories {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 22
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/lib/src/androidTest/java/me/ibrahimsn/lib/ExampleInstrumentedTest.java
+++ b/lib/src/androidTest/java/me/ibrahimsn/lib/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package me.ibrahimsn.lib;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/lib/src/main/java/me/ibrahimsn/lib/BottomBarParser.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/BottomBarParser.kt
@@ -3,7 +3,7 @@ package me.ibrahimsn.lib
 import android.content.Context
 import android.content.res.XmlResourceParser
 import android.graphics.drawable.Drawable
-import android.support.v4.content.ContextCompat
+import androidx.core.content.ContextCompat
 import org.xmlpull.v1.XmlPullParserException
 
 class BottomBarParser(private val context: Context, res: Int) {

--- a/lib/src/main/java/me/ibrahimsn/lib/NiceBottomBar.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/NiceBottomBar.kt
@@ -16,6 +16,7 @@ import android.annotation.SuppressLint
 import android.animation.ArgbEvaluator
 import android.graphics.*
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.drawable.DrawableCompat
 import kotlin.math.abs
 
 class NiceBottomBar : View {
@@ -124,7 +125,7 @@ class NiceBottomBar : View {
                 item.rect.centerX().toInt() + itemIconSize.toInt() / 2,
                 height / 2 - itemIconMargin.toInt() / 2)
 
-            item.icon.setTint(if (i == activeItem) currentActiveItemColor else itemTextColor)
+            DrawableCompat.setTint(item.icon , if (i == activeItem) currentActiveItemColor else itemTextColor)
             item.icon.draw(canvas)
 
             // Draw item title

--- a/lib/src/main/java/me/ibrahimsn/lib/NiceBottomBar.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/NiceBottomBar.kt
@@ -27,6 +27,7 @@ class NiceBottomBar : View {
     private var barIndicatorInterpolator = 4
     private var barIndicatorWidth = d2p(50f)
     private var barIndicatorEnabled = true
+    private var barIndicatorGravity = 1    // 0 -> TOP , 1 -> BOTTOM
     private var itemIconSize = d2p(18f)
     private var itemIconMargin = d2p(3f)
     private var itemTextColor = Color.parseColor("#444444")
@@ -81,6 +82,7 @@ class NiceBottomBar : View {
         itemIconMargin = typedArray.getDimension(R.styleable.NiceBottomBar_iconMargin, this.itemIconMargin)
         activeItem = typedArray.getInt(R.styleable.NiceBottomBar_activeItem, this.activeItem)
         barIndicatorInterpolator = typedArray.getInt(R.styleable.NiceBottomBar_indicatorInterpolator, this.barIndicatorInterpolator)
+        barIndicatorGravity = typedArray.getInt(R.styleable.NiceBottomBar_indicatorGravity, this.barIndicatorGravity)
         itemBadgeColor = typedArray.getColor(R.styleable.NiceBottomBar_badgeColor, this.itemBadgeColor)
         itemFontFamily = typedArray.getResourceId(R.styleable.NiceBottomBar_itemFontFamily, this.itemFontFamily)
         items = BottomBarParser(context, typedArray.getResourceId(R.styleable.NiceBottomBar_menu, 0)).parse()
@@ -117,13 +119,14 @@ class NiceBottomBar : View {
         super.onDraw(canvas)
 
         val textHeight = (paintText.descent() + paintText.ascent()) / 2
+        val additionalTopMargin = if (barIndicatorGravity == 1) 0f else 10f // push the item components from the top a bit if the indicator is at the top
 
         for ((i, item) in items.withIndex()) {
             item.icon.mutate()
             item.icon.setBounds(item.rect.centerX().toInt() - itemIconSize.toInt() / 2,
-                height / 2 - itemIconSize.toInt() - itemIconMargin.toInt() / 2,
+                height / 2 - itemIconSize.toInt() - itemIconMargin.toInt() / 2 + additionalTopMargin.toInt(),
                 item.rect.centerX().toInt() + itemIconSize.toInt() / 2,
-                height / 2 - itemIconMargin.toInt() / 2)
+                height / 2 - itemIconMargin.toInt() / 2 + additionalTopMargin.toInt())
 
             DrawableCompat.setTint(item.icon , if (i == activeItem) currentActiveItemColor else itemTextColor)
             item.icon.draw(canvas)
@@ -131,7 +134,7 @@ class NiceBottomBar : View {
             // Draw item title
             this.paintText.color = if (i == activeItem) currentActiveItemColor else itemTextColor
             canvas.drawText(item.title, item.rect.centerX(),
-                item.rect.centerY() - textHeight + itemIconSize / 2 + this.itemIconMargin / 2, paintText)
+                item.rect.centerY() - textHeight + itemIconSize / 2 + (this.itemIconMargin / 2) + additionalTopMargin, paintText)
 
             // Draw item badge
             if (item.badgeSize > 0)
@@ -140,8 +143,8 @@ class NiceBottomBar : View {
 
         // Draw indicator
         if (barIndicatorEnabled)
-            canvas.drawLine(indicatorLocation - barIndicatorWidth/2, height - 5.0f,
-                indicatorLocation + barIndicatorWidth/2, height - 5.0f, paintIndicator)
+            canvas.drawLine(indicatorLocation - barIndicatorWidth/2, (if (barIndicatorGravity == 1) height - 5.0f else 5f),
+                indicatorLocation + barIndicatorWidth/2, (if (barIndicatorGravity == 1) height - 5.0f else 5f), paintIndicator)
     }
 
     // Handle item clicks

--- a/lib/src/main/java/me/ibrahimsn/lib/NiceBottomBar.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/NiceBottomBar.kt
@@ -15,7 +15,7 @@ import android.view.MotionEvent
 import android.annotation.SuppressLint
 import android.animation.ArgbEvaluator
 import android.graphics.*
-import android.support.v4.content.res.ResourcesCompat
+import androidx.core.content.res.ResourcesCompat
 import kotlin.math.abs
 
 class NiceBottomBar : View {

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -23,5 +23,9 @@
 		    <enum name="overshoot" value="6"/>
 	    </attr>
 	    <attr name="badgeColor" format="color" />
+        <attr name="indicatorGravity" format="enum">
+            <enum name="top" value="0" />
+            <enum name="bottom" value="1" />
+        </attr>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
+ Update dependencies and migrate to AndroidX
+ Decrease minSdkVersion to 16  
   + Using `DrawableCompat` to handle drawable tint on api < 21
+ Add `indicatorGravity` attribute for more customization